### PR TITLE
unique user email migrations

### DIFF
--- a/src/dal/entity/user.entity.ts
+++ b/src/dal/entity/user.entity.ts
@@ -6,7 +6,7 @@ import { PasswordReset } from './passwordReset.entity';
 import { UserDevice } from './userDevice.entity';
 import { ShareableId } from './shareableId.entity';
 import { Block } from './block.entity';
-import { Cascade, Collection, Entity, IdentifiedReference, OneToMany, OneToOne, PrimaryKey, Property } from '@mikro-orm/core';
+import { Cascade, Collection, Entity, IdentifiedReference, OneToMany, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
  /* eslint-disable */ // needed for mikroorm default value & type which conflicts with typescript-eslint/no-unused-vars
 @ObjectType()
@@ -42,6 +42,7 @@ export class User extends ShareableId{
   public image?: string;
 
   @Field()
+  @Unique()
   @Property()
   public email!: string;
 

--- a/src/dal/migrations/postgres/.snapshot-postgres.json
+++ b/src/dal/migrations/postgres/.snapshot-postgres.json
@@ -354,6 +354,15 @@
       "indexes": [
         {
           "columnNames": [
+            "email"
+          ],
+          "composite": false,
+          "keyName": "user_email_unique",
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
             "passwordResetId"
           ],
           "composite": false,

--- a/src/dal/migrations/postgres/Migration20221113021755.ts
+++ b/src/dal/migrations/postgres/Migration20221113021755.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20221113021755 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "user" add constraint "user_email_unique" unique ("email");');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "user" drop constraint "user_email_unique";');
+  }
+
+}

--- a/src/dal/migrations/sqlite/Migration20221113021754.ts
+++ b/src/dal/migrations/sqlite/Migration20221113021754.ts
@@ -1,0 +1,9 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20221113021754 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('create unique index `user_email_unique` on `user` (`email`);');
+  }
+
+}


### PR DESCRIPTION
UI has in some occasions resulted in duplicate user entries in the DB. I've cleaned them up manually in preparation for this migration that asserts the user table's email column should be unique. I tested this first on a dump of the prod db locally.