### PR TITLE
Hub events resolver improvements

### DIFF
--- a/src/dal/field-resolvers/hub-field.resolver.ts
+++ b/src/dal/field-resolvers/hub-field.resolver.ts
@@ -1,3 +1,4 @@
+import { QueryOrder } from '@mikro-orm/core';
 import { Logger } from '@nestjs/common';
 import { Context, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { UserId } from '../../decorators/user.decorator';
@@ -48,6 +49,9 @@ export class HubFieldResolver {
         usersConnection: {
           user: userId
         }
+      },
+      orderBy: {
+        startDateTime: QueryOrder.DESC
       }
     });
     return events.loadItems();


### PR DESCRIPTION
- Users should only see events on a hub page that they're actually invited to
- Events on a hub should be sorted in descending order by start date time iso8601